### PR TITLE
Fixes for typos, translations, and language selection bug

### DIFF
--- a/GCBM/frmConfig.en-US.resx
+++ b/GCBM/frmConfig.en-US.resx
@@ -359,7 +359,7 @@
     <value>427, 26</value>
   </data>
   <data name="label17.Text" xml:space="preserve">
-    <value>Copies one or more files from one location (source) to another (destination). The file is not compressed, not part of any container, and not gargabe (garbage) removed.</value>
+    <value>Copies one or more files from one location (source) to another (destination). The file is not compressed, not part of any container, and not garbage (garbage) removed.</value>
   </data>
   <data name="grbTransferSystem.Text" xml:space="preserve">
     <value>Transfer system to be used</value>

--- a/GCBM/frmConfig.en-US.resx
+++ b/GCBM/frmConfig.en-US.resx
@@ -359,7 +359,7 @@
     <value>427, 26</value>
   </data>
   <data name="label17.Text" xml:space="preserve">
-    <value>Copies one or more files from one location (source) to another (destination). The file is not compressed, not part of any container, and not garbage (garbage) removed.</value>
+    <value>Copies one or more files from one location (source) to another (destination). The file is not compressed, not part of any container, and not garbage removed.</value>
   </data>
   <data name="grbTransferSystem.Text" xml:space="preserve">
     <value>Transfer system to be used</value>

--- a/GCBM/frmConfig.en-US.resx
+++ b/GCBM/frmConfig.en-US.resx
@@ -359,7 +359,7 @@
     <value>427, 26</value>
   </data>
   <data name="label17.Text" xml:space="preserve">
-    <value>Copies one or more files from one location (source) to another (destination). The file is not compressed, not part of any container, and not garbage removed.</value>
+    <value>Copies one or more files from one location (source) to another (destination). The file is not compressed, not part of any container, and no garbage data is removed.</value>
   </data>
   <data name="grbTransferSystem.Text" xml:space="preserve">
     <value>Transfer system to be used</value>

--- a/GCBM/frmConfig.es.resx
+++ b/GCBM/frmConfig.es.resx
@@ -831,4 +831,7 @@
   <data name="ofdDolphin.Filter" xml:space="preserve">
     <value>Emulador Dolphin|dolphin.exe</value>
   </data>
+  <data name="cbLanguage.Items3" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
 </root>

--- a/GCBM/frmConfig.es.resx
+++ b/GCBM/frmConfig.es.resx
@@ -396,7 +396,7 @@
     <value>420, 26</value>
   </data>
   <data name="label17.Text" xml:space="preserve">
-    <value>Copie uno o más archivos de una ubicación (fuente) a otra (destino). El archivo no está comprimido, no forma parte de ningún contenedor y no se elimina gargabe (basura).</value>
+    <value>Copie uno o más archivos de una ubicación (fuente) a otra (destino). El archivo no está comprimido, no forma parte de ningún contenedor y no se elimina garbage (basura).</value>
   </data>
   <data name="grbTransferSystem.Text" xml:space="preserve">
     <value>Sistema de transferencia a utilizar</value>

--- a/GCBM/frmConfig.ko.resx
+++ b/GCBM/frmConfig.ko.resx
@@ -617,16 +617,16 @@
     <value>언어:</value>
   </data>
   <data name="cbLanguage.Items" xml:space="preserve">
-    <value>포르투갈어 [브라질]</value>
+    <value>포르투갈어 [브라질 - BR]</value>
   </data>
   <data name="cbLanguage.Items1" xml:space="preserve">
-    <value>영어 [미국]</value>
+    <value>영어 [미국 - US]</value>
   </data>
   <data name="cbLanguage.Items2" xml:space="preserve">
-    <value>스페인어 [스페인]</value>
+    <value>스페인어 [스페인 - ES]</value>
   </data>
   <data name="cbLanguage.Items3" xml:space="preserve">
-    <value>한국인</value>
+    <value>한국인 [KR]</value>
   </data>
   <data name="grbLog.Text" xml:space="preserve">
     <value>기록</value>

--- a/GCBM/frmConfig.resx
+++ b/GCBM/frmConfig.resx
@@ -1705,7 +1705,7 @@
     <value>2</value>
   </data>
   <data name="label17.Text" xml:space="preserve">
-    <value>Copia um ou mais arquivos de um local (origem) para outro (destino). O arquivo não é comprimido, não faz parte de nenhum recipiente e nem tem o gargabe (lixo) removido.</value>
+    <value>Copia um ou mais arquivos de um local (origem) para outro (destino). O arquivo não é comprimido, não faz parte de nenhum recipiente e nem tem o garbage (lixo) removido.</value>
   </data>
   <data name="&gt;&gt;label17.Name" xml:space="preserve">
     <value>label17</value>

--- a/GCBM/frmConfig.resx
+++ b/GCBM/frmConfig.resx
@@ -4060,10 +4060,10 @@
     <value>True</value>
   </metadata>
   <data name="cbLanguage.Items" xml:space="preserve">
-    <value>English[US]</value>
+    <value>Português [Brasil]</value>
   </data>
   <data name="cbLanguage.Items1" xml:space="preserve">
-    <value>Português [Brasil]</value>
+    <value>English [US]</value>
   </data>
   <data name="cbLanguage.Items2" xml:space="preserve">
     <value>Español [ES]</value>

--- a/GCBM/frmInfoAdditional.en-US.resx
+++ b/GCBM/frmInfoAdditional.en-US.resx
@@ -154,7 +154,7 @@
     <value>LAUNCH:</value>
   </data>
   <data name="lblGenre.Text" xml:space="preserve">
-    <value>GENDER:</value>
+    <value>GENRE:</value>
   </data>
   <data name="lblLanguage.Text" xml:space="preserve">
     <value>LANGUAGE:</value>

--- a/GCBM/frmInfoAdditional.ko.resx
+++ b/GCBM/frmInfoAdditional.ko.resx
@@ -151,7 +151,7 @@
     <value>시작:</value>
   </data>
   <data name="lblGenre.Text" xml:space="preserve">
-    <value>성별:</value>
+    <value>장르:</value>
   </data>
   <data name="lblLanguage.Text" xml:space="preserve">
     <value>언어:</value>

--- a/GCBM/frmInformation.en-US.resx
+++ b/GCBM/frmInformation.en-US.resx
@@ -162,4 +162,7 @@
   <data name="label4.Text" xml:space="preserve">
     <value>Game ID:</value>
   </data>
+  <data name="grpDetailsSource.Text" xml:space="preserve">
+    <value>Details</value>
+  </data>
 </root>

--- a/GCBM/frmInformation.es.resx
+++ b/GCBM/frmInformation.es.resx
@@ -230,4 +230,7 @@
   <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="grpDetailsSource.Text" xml:space="preserve">
+    <value>Detalles</value>
+  </data>
 </root>

--- a/GCBM/frmInformation.ko.resx
+++ b/GCBM/frmInformation.ko.resx
@@ -162,4 +162,7 @@
   <data name="label4.Text" xml:space="preserve">
     <value>게임 ID:</value>
   </data>
+  <data name="grpDetailsSource.Text" xml:space="preserve">
+    <value>정보</value>
+  </data>
 </root>

--- a/GCBM/frmMain.en-US.resx
+++ b/GCBM/frmMain.en-US.resx
@@ -1508,4 +1508,7 @@
   <data name="tsmiSearchOnVGChartz.Text" xml:space="preserve">
     <value>Search on VGChartz</value>
   </data>
+  <data name="grpSearch.Text" xml:space="preserve">
+    <value>Search</value>
+  </data>
 </root>

--- a/GCBM/frmMain.en-US.resx
+++ b/GCBM/frmMain.en-US.resx
@@ -1511,4 +1511,7 @@
   <data name="grpSearch.Text" xml:space="preserve">
     <value>Search</value>
   </data>
+  <data name="grpDetailsDestiny.Text" xml:space="preserve">
+    <value>Details</value>
+  </data>
 </root>

--- a/GCBM/frmMain.es.resx
+++ b/GCBM/frmMain.es.resx
@@ -1602,4 +1602,7 @@
   <data name="grpSearch.Text" xml:space="preserve">
     <value>Buscar</value>
   </data>
+  <data name="grpDetailsDestiny.Text" xml:space="preserve">
+    <value>Detalles</value>
+  </data>
 </root>

--- a/GCBM/frmMain.es.resx
+++ b/GCBM/frmMain.es.resx
@@ -1599,4 +1599,7 @@
   <data name="lblDatabaseTotal.Text" xml:space="preserve">
     <value>0 Totales</value>
   </data>
+  <data name="grpSearch.Text" xml:space="preserve">
+    <value>Buscar</value>
+  </data>
 </root>

--- a/GCBM/frmMain.ko.resx
+++ b/GCBM/frmMain.ko.resx
@@ -1523,4 +1523,7 @@
   <data name="grpSearch.Text" xml:space="preserve">
     <value>검색</value>
   </data>
+  <data name="grpDetailsDestiny.Text" xml:space="preserve">
+    <value>정보</value>
+  </data>
 </root>

--- a/GCBM/frmMain.ko.resx
+++ b/GCBM/frmMain.ko.resx
@@ -1520,7 +1520,7 @@
   <data name="tsmiMainPlugins.Text" xml:space="preserve">
     <value>플러그인</value>
   </data>
-  <data name="grpSearch.txt" xml:space="preserve">
+  <data name="grpSearch.Text" xml:space="preserve">
     <value>검색</value>
   </data>
 </root>

--- a/GCBM/frmMain.ko.resx
+++ b/GCBM/frmMain.ko.resx
@@ -1520,4 +1520,7 @@
   <data name="tsmiMainPlugins.Text" xml:space="preserve">
     <value>플러그인</value>
   </data>
+  <data name="grpSearch.txt" xml:space="preserve">
+    <value>검색</value>
+  </data>
 </root>


### PR DESCRIPTION
I haven't tried compiling the program yet, or really deeply understanding how it's built, so I can only suggest minor translation fixes, for now, in `<file>.en-US.resx` files.

- Fixed redundant `garbage (garbage)` string in English
- Fixed `gargabe` to be `garbage` everywhere
- Fixed mistranslation `GENDER` to `GENRE`, in English
- Fixed mistranslation `[성별 (gender)` to `장르 (genre)`, in Korean
  - (I am not Korean, and do not speak Korean, so I'm just trying Google translate on this one)

---

**Question:**
If I want to add an English translation string for a word which has not yet been translated, such as below, how should I best do so?:
![image](https://user-images.githubusercontent.com/15176546/180694805-1a4dfddd-9d69-4fff-8f40-4f017ac79c88.png)

Can I just add this to `frmMain.en-US.resx`, and does its position in the file matter? And then do the same for each language, as long as it matches up with the related main Português file's `name` field?
```xml
<data name="grpSearch.Text" xml:space="preserve">
  <value>Search</value>
</data>
```