### PR TITLE
Better path, exception handling

### DIFF
--- a/GCBM/IniFile.cs
+++ b/GCBM/IniFile.cs
@@ -86,7 +86,7 @@ namespace GCBM
         /// <example>Inifile("C:\dados\exemplos","Configuracoes")</example>
         public IniFile(string path, string fileName)
         {
-            if (path.Substring(path.Length - 1, 1) != @"\\") path += "\\";
+            if (path.Substring(path.Length - 1, 1) != Path.DirectorySeparatorChar.ToString()) path += Path.DirectorySeparatorChar;
             this.fileName = path + corrigeFileName(fileName);
         }
 
@@ -98,14 +98,14 @@ namespace GCBM
         /// <example>Inifile("Configuracoes") , Inifile("c:\dados\exemplos\Configuracoes")</example>
         public IniFile(string fileName)
         {
-            if (fileName.IndexOf("\\") > -1)
+            if (fileName.IndexOf(Path.DirectorySeparatorChar) > -1)
             {
                 this.fileName = fileName;
             }
             else
             {
                 var strAppDir = Application.StartupPath;
-                this.fileName = strAppDir + "\\" + corrigeFileName(fileName);
+                this.fileName = strAppDir + Path.DirectorySeparatorChar + corrigeFileName(fileName);
             }
         }
 

--- a/GCBM/TOC.cs
+++ b/GCBM/TOC.cs
@@ -154,16 +154,16 @@ namespace GCBM
             {
                 fils = new List<TOCItemFil>();
                 fils.Add(new TOCItemFil(0, 0, 0, 99999, true, "root", "", resPath));
-                fils.Add(new TOCItemFil(1, 0, 0, 6, true, "&&SystemData", "&&systemdata\\",
-                    resPath + "&&systemdata\\"));
-                fils.Add(new TOCItemFil(2, 1, 0, 99999, false, "ISO.hdr", "&&SystemData\\iso.hdr",
-                    resPath + "&&SystemData\\iso.hdr"));
-                fils.Add(new TOCItemFil(3, 1, 9280, 99999, false, "AppLoader.ldr", "&&SystemData\\apploader.ldr",
-                    resPath + "&&SystemData\\apploader.ldr"));
-                fils.Add(new TOCItemFil(4, 1, 0, 99999, false, "Start.dol", "&&SystemData\\start.dol",
-                    resPath + "&&SystemData\\start.dol"));
-                fils.Add(new TOCItemFil(5, 1, 0, 99999, false, "Game.toc", "&&SystemData\\game.toc",
-                    resPath + "&&SystemData\\game.toc"));
+                fils.Add(new TOCItemFil(1, 0, 0, 6, true, "&&SystemData", "&&systemdata" + sio.Path.DirectorySeparatorChar,
+                    resPath + "&&systemdata" + sio.Path.DirectorySeparatorChar));
+                fils.Add(new TOCItemFil(2, 1, 0, 99999, false, "ISO.hdr", "&&SystemData" + sio.Path.DirectorySeparatorChar + "iso.hdr",
+                    resPath + "&&SystemData" + sio.Path.DirectorySeparatorChar + "iso.hdr"));
+                fils.Add(new TOCItemFil(3, 1, 9280, 99999, false, "AppLoader.ldr", "&&SystemData" + sio.Path.DirectorySeparatorChar + "apploader.ldr",
+                    resPath + "&&SystemData" + sio.Path.DirectorySeparatorChar + "apploader.ldr"));
+                fils.Add(new TOCItemFil(4, 1, 0, 99999, false, "Start.dol", "&&SystemData" + sio.Path.DirectorySeparatorChar + "start.dol",
+                    resPath + "&&SystemData" + sio.Path.DirectorySeparatorChar + "start.dol"));
+                fils.Add(new TOCItemFil(5, 1, 0, 99999, false, "Game.toc", "&&SystemData" + sio.Path.DirectorySeparatorChar + "game.toc",
+                    resPath + "&&SystemData" + sio.Path.DirectorySeparatorChar + "game.toc"));
 
                 totalLen = 0;
                 dataStart = totalLen;

--- a/GCBM/frmConfig.cs
+++ b/GCBM/frmConfig.cs
@@ -216,7 +216,7 @@ namespace GCBM
 
         private void LoadConfigFile()
         {
-            if (File.Exists(GET_CURRENT_PATH + @"\" + INI_FILE))
+            if (File.Exists(GET_CURRENT_PATH + Path.DirectorySeparatorChar + INI_FILE))
             {
                 // General
                 rbGeneralDiscClean.Checked = CONFIG_INI_FILE.IniReadBool("GENERAL", "DiscClean");
@@ -462,8 +462,8 @@ namespace GCBM
 
         #region Properties
 
-        private static readonly string TEMP_DIR = @"\temp";
-        private static readonly string COVERS_DIR = @"\cover\cache";
+        private static readonly string TEMP_DIR = Path.DirectorySeparatorChar + "temp";
+        private static readonly string COVERS_DIR = Path.DirectorySeparatorChar + "cover" + Path.DirectorySeparatorChar + "cache";
         private static readonly string PROG_UPDATE = "07/05/2022";
         private const string INI_FILE = "config.ini";
         private static readonly string GET_CURRENT_PATH = Directory.GetCurrentDirectory();

--- a/GCBM/frmDownloadGameTDB.cs
+++ b/GCBM/frmDownloadGameTDB.cs
@@ -43,7 +43,7 @@ namespace GCBM
             }
             catch (Exception ex)
             {
-                ex.Message.ToString();
+                MessageBox.Show(ex.Message);
             }
         }
 
@@ -61,18 +61,18 @@ namespace GCBM
 
             try
             {
-                ZipFile.ExtractToDirectory(GET_CURRENT_PATH + @"\" + WIITDB_ZIP_FILE, GET_CURRENT_PATH);
+                ZipFile.ExtractToDirectory(GET_CURRENT_PATH + Path.DirectorySeparatorChar + WIITDB_ZIP_FILE, GET_CURRENT_PATH);
             }
             catch (Exception ex)
             {
-                ex.Message.ToString();
+                MessageBox.Show(ex.Message);
             }
             finally
             {
-                File.Delete(GET_CURRENT_PATH + @"\" + WIITDB_ZIP_FILE);
+                File.Delete(GET_CURRENT_PATH + Path.DirectorySeparatorChar + WIITDB_ZIP_FILE);
 
                 await ProcessTaskDelay().ConfigureAwait(false);
-                var fileinfo = new FileInfo(GET_CURRENT_PATH + @"\" + WIITDB_FILE);
+                var fileinfo = new FileInfo(GET_CURRENT_PATH + Path.DirectorySeparatorChar + WIITDB_FILE);
                 if (fileinfo.Length >= 31035000) //31035596
                 {
                     lblConverting.Font = new Font(lblConverting.Font, FontStyle.Bold);

--- a/GCBM/frmMain.cs
+++ b/GCBM/frmMain.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -313,7 +314,7 @@ namespace GCBM
                     pbNetStatus.Image = Resources.conected_16;
                     lblNetStatus.ForeColor = Color.Black;
                     lblNetStatus.Text = Resources.NetworkCheck_NetStatus_Online;
-                    GlobalNotifications(Resources.NetworkCheck_NetStatus_Online, ToolTipIcon.Info);
+                    //GlobalNotifications(Resources.NetworkCheck_NetStatus_Online, ToolTipIcon.Info);
                 }
 
                 return;
@@ -451,8 +452,8 @@ namespace GCBM
             tbIDGame.Clear();
             tbIDDiscID.Clear();
             tbIDMakerCode.Clear();
-            pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\disc.png");
-            pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\3d.png");
+            pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "disc.png");
+            pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "3d.png");
             pbWebGameID.Enabled = false;
             pbWebGameID.Image = Resources.globe_earth_grayscale_64;
             dgvSource.DataSource = null;
@@ -559,7 +560,7 @@ namespace GCBM
         /// </summary>
         private void LoadConfigFile()
         {
-            if (sio.File.Exists(GET_CURRENT_PATH + @"\" + INI_FILE))
+            if (sio.File.Exists(GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + INI_FILE))
                 if (CONFIG_INI_FILE.IniReadBool("SEVERAL", "WindowMaximized"))
                     WindowState = FormWindowState.Maximized;
         }
@@ -631,8 +632,8 @@ namespace GCBM
             CONFIG_INI_FILE.IniWriteBool("TITLES", "GameTdbTitles", false);
             CONFIG_INI_FILE.IniWriteBool("TITLES", "GameInternalName", true);
             CONFIG_INI_FILE.IniWriteBool("TITLES", "GameXmlName", false);
-            CONFIG_INI_FILE.IniWriteString("TITLES", "LocationTitles", @"%APP%\titles.txt");
-            CONFIG_INI_FILE.IniWriteString("TITLES", "LocationCustomTitles", @"%APP%\custom-titles.txt");
+            CONFIG_INI_FILE.IniWriteString("TITLES", "LocationTitles", "%APP%" + Path.DirectorySeparatorChar + "titles.txt");
+            CONFIG_INI_FILE.IniWriteString("TITLES", "LocationCustomTitles", "%APP%" + Path.DirectorySeparatorChar + "custom-titles.txt");
             CONFIG_INI_FILE.IniWriteInt("TITLES", "TitleLanguage", 0);
             // Dolphin Emulator
             CONFIG_INI_FILE.IniWriteString("DOLPHIN", "DolphinFolder", "");
@@ -705,6 +706,7 @@ namespace GCBM
                 catch (Exception ex)
                 {
                     tbLog.AppendText("[" + DateString() + "]" + Resources.Info + ex.Message);
+                    tbLog.AppendText(ex.Message + Environment.NewLine + ex.StackTrace);
                     GlobalNotifications(ex.Message, ToolTipIcon.Error);
                 }
         }
@@ -758,6 +760,7 @@ namespace GCBM
                 }
                 catch (Exception ex)
                 {
+                    tbLog.AppendText(ex.Message + Environment.NewLine + ex.StackTrace);
                 }
 
             tsmiSelectGameList.Enabled = true;
@@ -862,6 +865,7 @@ namespace GCBM
                 {
                     // Not used.
                     // Just to avoid mistakes.
+                    tbLog.AppendText(ex.Message + Environment.NewLine + ex.StackTrace);
                 }
 
             return filesFound.ToArray();
@@ -1081,8 +1085,8 @@ namespace GCBM
                     GlobalNotifications(Resources.NotNintendoGameCubeFile + Environment.NewLine +
                                         Resources.RecommendedDeleteOrMoveFile, ToolTipIcon.Info);
 
-                    pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\disc.png");
-                    pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\3d.png");
+                    pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "disc.png");
+                    pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "3d.png");
 
                     ERROR = true;
                     // INVALID FILE!!!
@@ -1126,8 +1130,8 @@ namespace GCBM
                     GlobalNotifications(Resources.NotNintendoGameCubeFile + Environment.NewLine +
                                         Resources.RecommendedDeleteOrMoveFile, ToolTipIcon.Info);
 
-                    pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\disc.png");
-                    pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\3d.png");
+                    pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "disc.png");
+                    pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "3d.png");
 
                     ERROR = true;
                     // INVALID FILE!!!
@@ -1221,19 +1225,19 @@ namespace GCBM
             }
             catch (Exception ex)
             {
-                tbLog.Text = ex.ToString();
+                tbLog.AppendText(ex.Message + Environment.NewLine + ex.StackTrace);
             }
 
-            if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\" + _idGame + ".png"))
-                pbGameDisc.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\" + _idGame + ".png");
+            if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar + _idGame + ".png"))
+                pbGameDisc.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar + _idGame + ".png");
             else
-                pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\disc.png");
+                pbGameDisc.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "disc.png");
 
-            if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\3d\" + _idGame + ".png"))
-                pbGameCover3D.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\3d\" + _idGame +
+            if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar + _idGame + ".png"))
+                pbGameCover3D.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar + _idGame +
                                         ".png");
             else
-                pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + @"\3d.png");
+                pbGameCover3D.LoadAsync(GET_CURRENT_PATH + MEDIA_DIR + sio.Path.DirectorySeparatorChar + "3d.png");
         }
 
         #endregion
@@ -1306,7 +1310,7 @@ namespace GCBM
                         tbLog.AppendText("[" + DateString() + "]" + Resources.DownloadDiscCover + _IDMakerCode +
                                          ".png" + Environment.NewLine);
                         NET_CLIENT.DownloadFileAsync(myLinkCoverDisc,
-                            GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\" + _IDMakerCode + ".png");
+                            GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar + _IDMakerCode + ".png");
                         while (NET_CLIENT.IsBusy) Application.DoEvents();
                     }
                 }
@@ -1314,6 +1318,7 @@ namespace GCBM
                 {
                     tbLog.AppendText("[" + DateString() + "]" + Resources.DownloadDiscCoverError + Environment.NewLine +
                                      Resources.Error + ex.Message + Environment.NewLine);
+                    tbLog.AppendText(ex.StackTrace);
                 }
                 finally
                 {
@@ -1331,7 +1336,7 @@ namespace GCBM
                 //    if (NET_RESPONSE.StatusCode == HttpStatusCode.OK)
                 //    {
                 //        tbLog.AppendText("[" + DateString() + "]" + GCBM.Properties.Resources.DownloadDiscCover + _IDMakerCode + ".png" + Environment.NewLine);
-                //        NET_CLIENT.DownloadFileAsync(myLinkCoverDisc, GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\" + _IDMakerCode + ".png");
+                //        NET_CLIENT.DownloadFileAsync(myLinkCoverDisc, GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar + _IDMakerCode + ".png");
                 //        while (NET_CLIENT.IsBusy) { Application.DoEvents(); }
                 //    }
                 //}
@@ -1339,6 +1344,7 @@ namespace GCBM
                 //{
                 //    tbLog.AppendText("[" + DateString() + "]" + GCBM.Properties.Resources.DownloadDiscCoverError + Environment.NewLine +
                 //        GCBM.Properties.Resources.Error + ex.Message + Environment.NewLine);
+                //    tbLob.AppendText(ex.StackTrace);
                 //}
                 //finally
                 //{
@@ -1362,7 +1368,7 @@ namespace GCBM
                         tbLog.AppendText("[" + DateString() + "]" + Resources.Download3DCover + _IDMakerCode + ".png" +
                                          Environment.NewLine);
                         NET_CLIENT.DownloadFileAsync(myLinkCover3D,
-                            GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\3d\" + _IDMakerCode + ".png");
+                            GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar+ "3d" + sio.Path.DirectorySeparatorChar + _IDMakerCode + ".png");
                         while (NET_CLIENT.IsBusy) Application.DoEvents();
                     }
                 }
@@ -1370,6 +1376,7 @@ namespace GCBM
                 {
                     tbLog.AppendText("[" + DateString() + "]" + Resources.Download3DCoverError + Environment.NewLine +
                                      Resources.Error + ex.Message + Environment.NewLine);
+                    tbLog.AppendText(ex.StackTrace);
                 }
                 finally
                 {
@@ -1449,7 +1456,7 @@ namespace GCBM
                         tbLog.AppendText("[" + DateString() + "]" + Resources.DownloadDiscCover + _IDMakerCode +
                                          ".png" + Environment.NewLine);
                         NET_CLIENT.DownloadFileAsync(myLinkCoverDisc,
-                            GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\" + _IDMakerCode + ".png");
+                            GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar + _IDMakerCode + ".png");
                         while (NET_CLIENT.IsBusy) Application.DoEvents();
                     }
                 }
@@ -1458,6 +1465,7 @@ namespace GCBM
                     //MessageBox.Show("ARQUIVO: " + _netResponse.ToString() + " not found!");
                     tbLog.AppendText("[" + DateString() + "]" + Resources.DownloadDiscCoverError + Environment.NewLine +
                                      "[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                    tbLog.AppendText(ex.StackTrace);
                 }
                 finally
                 {
@@ -1478,7 +1486,7 @@ namespace GCBM
                         tbLog.AppendText("[" + DateString() + "]" + Resources.Download3DCover + _IDMakerCode + ".png" +
                                          Environment.NewLine);
                         NET_CLIENT.DownloadFileAsync(myLinkCover3D,
-                            GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\3d\" + _IDMakerCode + ".png");
+                            GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar + _IDMakerCode + ".png");
                         while (NET_CLIENT.IsBusy) Application.DoEvents();
                     }
                 }
@@ -1487,6 +1495,7 @@ namespace GCBM
                     //MessageBox.Show("ARQUIVO: " + _netResponse.ToString() + " not found!");
                     tbLog.AppendText("[" + DateString() + "]" + Resources.Download3DCoverError + Environment.NewLine +
                                      "[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                    tbLog.AppendText(ex.StackTrace);
                 }
                 finally
                 {
@@ -1530,6 +1539,7 @@ namespace GCBM
             catch (Exception ex)
             {
                 tbLog.AppendText("[" + DateString() + "]" + Resources.ClearTemp_String1 + Environment.NewLine);
+                tbLog.AppendText(ex.StackTrace);
             }
         }
 
@@ -1559,50 +1569,50 @@ namespace GCBM
             if (!sio.Directory.Exists(GET_CURRENT_PATH + COVERS_DIR))
             {
                 // US - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\US\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\US\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\US\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\US\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "US" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "US" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "US" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "US" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // JA - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\JA\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\JA\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\JA\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\JA\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "JA" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "JA" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "JA" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "JA" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // EN - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\EN\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\EN\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\EN\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\EN\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "EN" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "EN" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "EN" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "EN" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // DE - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\DE\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\DE\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\DE\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\DE\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "DE" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "DE" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "DE" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "DE" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // ES - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\ES\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\ES\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\ES\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\ES\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "ES" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "ES" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "ES" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "ES" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // IT - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\IT\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\IT\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\IT\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\IT\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "IT" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "IT" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "IT" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "IT" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // AU - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\AU\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\AU\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\AU\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\AU\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "AU" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "AU" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "AU" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "AU" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // NL - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\NL\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\NL\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\NL\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\NL\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "NL" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "NL" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "NL" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "NL" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
                 // FR - Covers Directory
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\FR\2d\"); // 2D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\FR\3d\"); // 3D
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\FR\disc\"); // Disc
-                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + @"\FR\full\"); // Full
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "FR" + sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar); // 2D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "FR" + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar); // 3D
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "FR" + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar); // Disc
+                sio.Directory.CreateDirectory(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + "FR" + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar); // Full
 
                 tbLog.AppendText("[" + DateString() + "]" + Resources.RequiredDirectories_String4 +
                                  Environment.NewLine);
@@ -1637,6 +1647,7 @@ namespace GCBM
             catch (Exception ex)
             {
                 tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                tbLog.AppendText(ex.StackTrace);
                 GlobalNotifications(ex.Message, ToolTipIcon.Error);
             }
         }
@@ -1720,14 +1731,14 @@ namespace GCBM
                                 LINK_DOMAIN = "EN";
                             //GlobalNotifications(GCBM.Properties.Resources.UnknownRegion, ToolTipIcon.Info);
 
-                            var cover2D = GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\2d\" + tbIDGame.Text +
-                                          ".png";
-                            var cover3D = GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\3d\" + tbIDGame.Text +
-                                          ".png";
-                            var coverDisc = GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\" +
-                                            tbIDGame.Text + ".png";
-                            var coverFull = GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\full\" +
-                                            tbIDGame.Text + ".png";
+                            var cover2D = GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar
+                                + "2d" + sio.Path.DirectorySeparatorChar + tbIDGame.Text + ".png";
+                            var cover3D = GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar
+                                + "3d" + sio.Path.DirectorySeparatorChar + tbIDGame.Text + ".png";
+                            var coverDisc = GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar
+                                + "disc" + sio.Path.DirectorySeparatorChar + tbIDGame.Text + ".png";
+                            var coverFull = GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar
+                                + "full" + sio.Path.DirectorySeparatorChar + tbIDGame.Text + ".png";
 
                             // DELETAR JOGO E CAPA DO DISPOSITIVO DE ORIGEM
                             if (dgv == dgvSource)
@@ -1749,7 +1760,7 @@ namespace GCBM
                             {
                                 var pasta = sio.Path.GetDirectoryName(dgv.CurrentRow.Cells["Path"].Value.ToString());
                                 sio.Directory.Delete(pasta, true);
-                                DisplayFilesSelected(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\", dgvDestination);
+                                DisplayFilesSelected(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar, dgvDestination);
                             }
                         }
 
@@ -1762,6 +1773,7 @@ namespace GCBM
                     catch (Exception ex)
                     {
                         tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                        tbLog.AppendText(ex.StackTrace);
                         GlobalNotifications(ex.Message, ToolTipIcon.Error);
                     }
             }
@@ -1800,21 +1812,21 @@ namespace GCBM
                                 LINK_DOMAIN = "EN";
                             //GlobalNotifications(GCBM.Properties.Resources.UnknownRegion, ToolTipIcon.Info);
 
-                            var di2D = new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN +
-                                                             @"\2d\");
-                            var di3D = new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN +
-                                                             @"\3d\");
+                            var di2D = new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN +
+                                                             sio.Path.DirectorySeparatorChar + "2d" + sio.Path.DirectorySeparatorChar);
+                            var di3D = new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN +
+                                                             sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar);
                             var diDisc =
-                                new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\disc\");
+                                new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "disc" + sio.Path.DirectorySeparatorChar);
                             var diFull =
-                                new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + @"\" + LINK_DOMAIN + @"\full\");
+                                new sio.DirectoryInfo(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + LINK_DOMAIN + sio.Path.DirectorySeparatorChar + "full" + sio.Path.DirectorySeparatorChar);
 
                             var files = await GetFilesFolder(fbd1.SelectedPath, filters, false).ConfigureAwait(false);
 
                             // Goes through the entire file list and removes all found ISO and GCM files.
                             for (var i = 0; i < files.Length; i++)
                             {
-                                //File.Delete(fbd1.SelectedPath + @"\" + dgvSource.CurrentRow.Cells["Title"].Value.ToString());
+                                //File.Delete(fbd1.SelectedPath + sio.Path.DirectorySeparatorChar + dgvSource.CurrentRow.Cells["Title"].Value.ToString());
                                 sio.File.Delete(dgv.CurrentRow.Cells["Path"].Value.ToString());
 
                                 DisplayFilesSelected(fbd1.SelectedPath, dgv);
@@ -1838,7 +1850,7 @@ namespace GCBM
                         } // DELETAR JOGO DO DISPOSITIVO DE DESTINO
                         else if (dgv == dgvSource)
                         {
-                            var files = await GetFilesFolder(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\", filters,
+                            var files = await GetFilesFolder(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar, filters,
                                 false).ConfigureAwait(false);
 
                             // Goes through the entire file list and removes all found ISO and GCM files.
@@ -1846,11 +1858,11 @@ namespace GCBM
                             for (var i = 0; i < files.Length; i++)
                             {
                                 var folder = sio.Path.GetDirectoryName(dgv.CurrentRow.Cells["Path"].Value.ToString());
-                                //File.Delete(tscbDiscDrive.SelectedItem + @"games\" + dgv.CurrentRow.Cells[0].Value.ToString());                               
+                                //File.Delete(tscbDiscDrive.SelectedItem + "games" + sio.Path.DirectorySeparatorChar + dgv.CurrentRow.Cells[0].Value.ToString());                               
                                 sio.Directory.Delete(folder, true);
                                 //MessageBox.Show(pasta);
 
-                                DisplayFilesSelected(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\", dgv);
+                                DisplayFilesSelected(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar, dgv);
                             }
 
                             //dgvSource.DataSource = null;
@@ -1898,6 +1910,7 @@ namespace GCBM
                 catch (Exception ex)
                 {
                     tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                    tbLog.AppendText(ex.StackTrace);
                     GlobalNotifications(ex.Message, ToolTipIcon.Error);
                 }
         }
@@ -2018,6 +2031,7 @@ namespace GCBM
                 catch (Exception ex)
                 {
                     tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                    tbLog.AppendText(ex.StackTrace);
                     GlobalNotifications(ex.Message, ToolTipIcon.Error);
                 }
         }
@@ -2111,7 +2125,7 @@ namespace GCBM
             else
                 try
                 {
-                    sio.TextWriter writer = new sio.StreamWriter(GET_CURRENT_PATH + @"\gamelist.txt");
+                    sio.TextWriter writer = new sio.StreamWriter(GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + "gamelist.txt");
                     for (var i = 0; i < dgv.Rows.Count - 1; i++)
                     {
                         for (var j = 1; j < dgv.Columns.Count; j++)
@@ -2145,7 +2159,7 @@ namespace GCBM
             {
                 if (tbLog.Text != string.Empty)
                 {
-                    sio.File.WriteAllText(GET_CURRENT_PATH + @"\" + "gcbm.log", tbLog.Text);
+                    sio.File.WriteAllText(GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + "gcbm.log", tbLog.Text);
                     GlobalNotifications(Resources.RecordExportedSuccessfully, ToolTipIcon.Info);
                 }
                 else
@@ -2155,7 +2169,7 @@ namespace GCBM
             }
             else
             {
-                if (tbLog.Text != string.Empty) sio.File.WriteAllText(GET_CURRENT_PATH + @"\" + "gcbm.log", tbLog.Text);
+                if (tbLog.Text != string.Empty) sio.File.WriteAllText(GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + "gcbm.log", tbLog.Text);
             }
         }
 
@@ -2256,52 +2270,52 @@ namespace GCBM
                             {
                                 InvalidDrive(d.DriveFormat);
 
-                                if (!sio.Directory.Exists(tscbDiscDrive.Text + @"\" + GAMES_DIR))
+                                if (!sio.Directory.Exists(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR))
                                 {
                                     var result = MessageBox.Show(Resources.CreateGamesFolder,
                                         Resources.Attention, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
                                     if (result == DialogResult.Yes)
-                                        sio.Directory.CreateDirectory(tscbDiscDrive.Text + @"\" + GAMES_DIR);
+                                        sio.Directory.CreateDirectory(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR);
                                 }
                                 else
                                 {
                                     // If the GAMES directory already exists, load the content recursively.
-                                    DisplayFilesSelected(tscbDiscDrive.Text + @"\" + GAMES_DIR, dgvDestination);
+                                    DisplayFilesSelected(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR, dgvDestination);
                                 }
                             }
                             else if (d.DriveFormat == EXFAT_FAT64) // EXFAT (FAT64)
                             {
                                 InvalidDrive(d.DriveFormat);
 
-                                if (!sio.Directory.Exists(tscbDiscDrive.Text + @"\" + GAMES_DIR))
+                                if (!sio.Directory.Exists(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR))
                                 {
                                     var result = MessageBox.Show(Resources.CreateGamesFolder,
                                         Resources.Attention, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
                                     if (result == DialogResult.Yes)
-                                        sio.Directory.CreateDirectory(tscbDiscDrive.Text + @"\" + GAMES_DIR);
+                                        sio.Directory.CreateDirectory(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR);
                                 }
                                 else
                                 {
                                     // If the GAMES directory already exists, load the content recursively.
-                                    DisplayFilesSelected(tscbDiscDrive.Text + @"\" + GAMES_DIR, dgvDestination);
+                                    DisplayFilesSelected(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR, dgvDestination);
                                 }
                             }
                             else // FAT32 
                             {
-                                if (!sio.Directory.Exists(tscbDiscDrive.Text + @"\" + GAMES_DIR))
+                                if (!sio.Directory.Exists(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR))
                                 {
                                     var result = MessageBox.Show(Resources.CreateGamesFolderNow,
                                         Resources.Attention, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
                                     if (result == DialogResult.Yes)
-                                        sio.Directory.CreateDirectory(tscbDiscDrive.Text + @"\" + GAMES_DIR);
+                                        sio.Directory.CreateDirectory(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR);
                                 }
                                 else
                                 {
                                     // If the GAMES directory already exists, load the content recursively.
-                                    DisplayFilesSelected(tscbDiscDrive.Text + @"\" + GAMES_DIR, dgvDestination);
+                                    DisplayFilesSelected(tscbDiscDrive.Text + sio.Path.DirectorySeparatorChar + GAMES_DIR, dgvDestination);
                                 }
                             }
                             //label6.Text = "Total Size: " + d.TotalSize / (1024 * 1024) + " MB\nDrive Format: " + d.DriveFormat + " \nAvailable: " + d.AvailableFreeSpace / (1024 * 1024) + " MB\n" + d.DriveType;
@@ -2314,6 +2328,7 @@ namespace GCBM
             catch (Exception ex)
             {
                 tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                tbLog.AppendText(ex.StackTrace);
                 GlobalNotifications(ex.Message, ToolTipIcon.Error);
             }
         }
@@ -2406,11 +2421,11 @@ namespace GCBM
                         _region = "EN";
 
                     // Take the Disc covers from the device
-                    if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + @"\" + _region + @"\disc\" +
-                                        lvDatabase.SelectedItems[0].Text + ".png"))
+                    if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + _region + sio.Path.DirectorySeparatorChar
+                        + "disc" + sio.Path.DirectorySeparatorChar + lvDatabase.SelectedItems[0].Text + ".png"))
                     {
-                        pbGameDisc.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + @"\" + _region + @"\disc\" +
-                                             lvDatabase.SelectedItems[0].Text + ".png");
+                        pbGameDisc.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + _region + sio.Path.DirectorySeparatorChar
+                            + "disc" + sio.Path.DirectorySeparatorChar + lvDatabase.SelectedItems[0].Text + ".png");
                     }
                     else
                     {
@@ -2430,7 +2445,7 @@ namespace GCBM
                         }
                         catch (WebException ex)
                         {
-                            GlobalNotifications(Resources.ServerReportedDiscCoverNotFound, ToolTipIcon.Error);
+                            GlobalNotifications(Resources.ServerReportedDiscCoverNotFound + " " + ex.Message, ToolTipIcon.Error);
                         }
                         finally
                         {
@@ -2439,11 +2454,11 @@ namespace GCBM
                     }
 
                     //Grab the device's 3D covers
-                    if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + @"\" + _region + @"\3d\" +
-                                        lvDatabase.SelectedItems[0].Text + ".png"))
+                    if (sio.File.Exists(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + _region + sio.Path.DirectorySeparatorChar
+                        + "3d" + sio.Path.DirectorySeparatorChar + lvDatabase.SelectedItems[0].Text + ".png"))
                     {
-                        pbGameCover3D.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + @"\" + _region + @"\3d\" +
-                                                lvDatabase.SelectedItems[0].Text + ".png");
+                        pbGameCover3D.LoadAsync(GET_CURRENT_PATH + COVERS_DIR + sio.Path.DirectorySeparatorChar + _region
+                            + sio.Path.DirectorySeparatorChar + "3d" + sio.Path.DirectorySeparatorChar + lvDatabase.SelectedItems[0].Text + ".png");
                     }
                     else
                     {
@@ -2463,7 +2478,7 @@ namespace GCBM
                         }
                         catch (WebException ex)
                         {
-                            GlobalNotifications(Resources.ServerReported3DCoverNotFound, ToolTipIcon.Error);
+                            GlobalNotifications(Resources.ServerReported3DCoverNotFound + " " + ex.Message, ToolTipIcon.Error);
                         }
                         finally
                         {
@@ -2540,6 +2555,7 @@ namespace GCBM
             catch (Exception ex)
             {
                 tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                tbLog.AppendText(ex.StackTrace);
                 GlobalNotifications(ex.Message, ToolTipIcon.Error);
             }
         }
@@ -2750,13 +2766,13 @@ namespace GCBM
         #region Properties
 
         private static readonly string GET_CURRENT_PATH = sio.Directory.GetCurrentDirectory();
-        private static readonly string GAMES_DIR = @"games";
-        private static readonly string TEMP_DIR = @"\temp";
-        private static readonly string COVERS_DIR = @"\covers\cache";
-        private static readonly string MEDIA_DIR = @"\media\covers";
+        private static readonly string GAMES_DIR = "games";
+        private static readonly string TEMP_DIR = sio.Path.DirectorySeparatorChar + "temp";
+        private static readonly string COVERS_DIR = sio.Path.DirectorySeparatorChar + "covers" + sio.Path.DirectorySeparatorChar + "cache";
+        private static readonly string MEDIA_DIR = sio.Path.DirectorySeparatorChar + "media" + sio.Path.DirectorySeparatorChar + "covers";
         private static readonly string CULTURE_CURRENT = "pt-BR";
         private static readonly string PROG_UPDATE = "10/07/2022";
-        private static string FAT32 = "FAT32";
+        private static readonly string FAT32 = "FAT32";
         private static readonly string NTFS = "NTFS";
         private static readonly string EXFAT_FAT64 = "EXFAT";
 
@@ -2899,6 +2915,7 @@ namespace GCBM
             {
                 // Not used.
                 // Just to avoid mistakes.
+                tbLog.AppendText(ex.Message + Environment.NewLine + ex.StackTrace);
             }
         }
 
@@ -2916,7 +2933,7 @@ namespace GCBM
             }
             catch (Exception ex)
             {
-                tbLog.AppendText(ex.Message);
+                tbLog.AppendText(ex.Message + Environment.NewLine + ex.StackTrace);
             }
         }
 
@@ -3027,7 +3044,7 @@ namespace GCBM
             START_INFO.CreateNoWindow = true;
             START_INFO.UseShellExecute = true;
             // GCIT
-            START_INFO.FileName = GET_CURRENT_PATH + @"\bin\gcit.exe ";
+            START_INFO.FileName = GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + "bin" + sio.Path.DirectorySeparatorChar + "gcit.exe ";
 
 
             var boolCaseSwitch = CONFIG_INI_FILE.IniReadBool("TRANSFERSYSTEM", "ScrubFlushSD");
@@ -3150,7 +3167,7 @@ namespace GCBM
 
                     if (tbIDDiscID.Text == "0x00")
                     {
-                        GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
+                        //GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
                         //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String5, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                         lblCopy.Visible = false;
@@ -3165,11 +3182,11 @@ namespace GCBM
                         if (CONFIG_INI_FILE.IniReadBool("TITLES", "GameInternalName"))
                         {
                             // Renomear game.iso -> disc2.iso
-                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" + tbIDName.Text + " [" +
-                                           tbIDGame.Text + "2]" + @"\game.iso";
-                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + tbIDName.Text + " [" +
+                                           tbIDGame.Text + "2]" + sio.Path.DirectorySeparatorChar + "game.iso";
+                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                             tbIDName.Text.Replace("disc2 ", "") + " [" + tbIDGame.Text + "2]" +
-                                            @"\disc2.iso";
+                                            sio.Path.DirectorySeparatorChar + "disc2.iso";
 
                             //MessageBox.Show("MYORIGEM: " + Environment.NewLine
                             //    + myOrigem +
@@ -3183,7 +3200,7 @@ namespace GCBM
 
                             sio.File.Move(myOrigem, myDestiny);
 
-                            GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                            //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                             //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String6, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                             lblCopy.Visible = false;
@@ -3195,11 +3212,11 @@ namespace GCBM
                         else
                         {
                             // Renomear game.iso -> disc2.iso
-                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" + tbIDName.Text + " [" +
-                                           _IDMakerCode + "2]" + @"\game.iso";
-                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + tbIDName.Text + " [" +
+                                           _IDMakerCode + "2]" + sio.Path.DirectorySeparatorChar + "game.iso";
+                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                             tbIDName.Text.Replace("disc2 ", "") + " [" + _IDMakerCode + "2]" +
-                                            @"\disc2.iso";
+                                            sio.Path.DirectorySeparatorChar + "disc2.iso";
 
                             //MessageBox.Show("MYORIGEM: " + Environment.NewLine
                             //    + myOrigem +
@@ -3213,7 +3230,7 @@ namespace GCBM
 
                             sio.File.Move(myOrigem, myDestiny);
 
-                            GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                            //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                             //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String6, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                             lblCopy.Visible = false;
@@ -3249,7 +3266,7 @@ namespace GCBM
                 START_INFO.CreateNoWindow = true;
                 START_INFO.UseShellExecute = true;
                 // GCIT
-                START_INFO.FileName = GET_CURRENT_PATH + @"\bin\gcit.exe ";
+                START_INFO.FileName = GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + "bin" + sio.Path.DirectorySeparatorChar + "gcit.exe ";
 
 
                 var boolCaseSwitch = CONFIG_INI_FILE.IniReadBool("TRANSFERSYSTEM", "ScrubFlushSD");
@@ -3361,7 +3378,7 @@ namespace GCBM
 
                         if (tbIDDiscID.Text == "0x00")
                         {
-                            GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
+                            //GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
                             //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String5, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                             lblCopy.Visible = false;
@@ -3376,11 +3393,11 @@ namespace GCBM
                             if (CONFIG_INI_FILE.IniReadBool("TITLES", "GameInternalName"))
                             {
                                 // Renomear game.iso -> disc2.iso
-                                var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" + tbIDName.Text + " [" +
-                                               tbIDGame.Text + "2]" + @"\game.iso";
-                                var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                                var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + tbIDName.Text + " [" +
+                                               tbIDGame.Text + "2]" + sio.Path.DirectorySeparatorChar + "game.iso";
+                                var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                 tbIDName.Text.Replace("disc2 ", "") + " [" + tbIDGame.Text + "2]" +
-                                                @"\disc2.iso";
+                                                sio.Path.DirectorySeparatorChar + "disc2.iso";
 
                                 //MessageBox.Show("MYORIGEM: " + Environment.NewLine
                                 //    + myOrigem +
@@ -3394,7 +3411,7 @@ namespace GCBM
 
                                 sio.File.Move(myOrigem, myDestiny);
 
-                                GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                                //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                                 //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String6, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                                 lblCopy.Visible = false;
@@ -3406,12 +3423,12 @@ namespace GCBM
                             else
                             {
                                 // Renomear game.iso -> disc2.iso
-                                var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                                var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                InstallQueue[intQueuePos].Title + " [" + InstallQueue[intQueuePos].ID +
-                                               "2]" + @"\game.iso";
-                                var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                                               "2]" + sio.Path.DirectorySeparatorChar + "game.iso";
+                                var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                 InstallQueue[intQueuePos].Title.Replace("disc2 ", "") + " [" +
-                                                InstallQueue[intQueuePos].ID + "2]" + @"\disc2.iso";
+                                                InstallQueue[intQueuePos].ID + "2]" + sio.Path.DirectorySeparatorChar + "disc2.iso";
 
                                 //MessageBox.Show("MYORIGEM: " + Environment.NewLine
                                 //    + myOrigem +
@@ -3424,7 +3441,7 @@ namespace GCBM
                             */
                                 sio.File.Move(myOrigem, myDestiny);
 
-                                GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                                //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                                 //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String6, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                                 lblCopy.Visible = false;
@@ -3506,9 +3523,10 @@ namespace GCBM
                         {
                             CheckAndCallCopyTask(InstallQueue[intQueuePos].Path);
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            tbLog.Text += "\n" + DateTime.Now + " Error Installing: \n" + e.Message + "\n";
+                            tbLog.AppendText("[" + DateTime.Now + "] Error Installing: " + Environment.NewLine + ex.Message + Environment.NewLine);
+                            tbLog.AppendText(ex.StackTrace);
                         }
                 })));
             }
@@ -3551,7 +3569,7 @@ namespace GCBM
             lblCopy.Text = Resources.CopyTask_String3;
             lblInstallGame.Text = Resources.CopyTask_String4;
             lblPercent.Text = Resources.CopyTask_String5;
-            GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
+            //GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
             EnableOptionsGameList();
             dgvSource.Enabled = true;
             pbCopy.Visible = false;
@@ -3777,10 +3795,11 @@ namespace GCBM
                 tbLog.Text += "\n HTML exported sucessfully at: \n" + caminho + "\n";
                 MessageBox.Show("File has been saved at: " + caminho, "Sucess!");
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                MessageBox.Show("ERROR! Please post report this to Github or GBATemp.\n" + e.Message, "ERROR!");
-                tbLog.Text += "\n" + "HTML Export error\n" + e.Message + "\n" + DateTime.Now.ToString("hh:mm:ss tt");
+                MessageBox.Show("ERROR! Please post report this to Github or GBATemp.\n" + ex.Message, "ERROR!");
+                tbLog.AppendText("[" + DateTime.Now.ToString("hh:mm:ss tt") + "] HTML Export error" + Environment.NewLine + ex.Message + Environment.NewLine);
+                tbLog.AppendText(ex.StackTrace);
             }
         }
 
@@ -3874,7 +3893,7 @@ namespace GCBM
         //                catch (IOException ex)
         //                {
         //                    fileError = true;
-        //                    GlobalNotifications(GCBM.Properties.Resources.UnableWriteDataDisk, ToolTipIcon.Error);
+        //                    GlobalNotifications(GCBM.Properties.Resources.UnableWriteDataDisk + " " + ex.Message, ToolTipIcon.Error);
         //                }
         //            }
         //            if (!fileError)
@@ -3905,6 +3924,7 @@ namespace GCBM
         //                catch (Exception ex)
         //                {
         //                    tbLog.AppendText("[" + DateString() + "]" + GCBM.Properties.Resources.Error + ex.Message + Environment.NewLine);
+        //                    tbLog.AppendText(ex.StackTrace);
         //                    GlobalNotifications(ex.Message, ToolTipIcon.Error);
         //                }
         //            }
@@ -4154,7 +4174,7 @@ namespace GCBM
 
         private void tsmiReloadGameListDisc_Click(object sender, EventArgs e)
         {
-            DisplayFilesSelected(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\", dgvDestination);
+            DisplayFilesSelected(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar, dgvDestination);
         }
 
         #endregion
@@ -4242,7 +4262,7 @@ namespace GCBM
                 if (dialog.ShowDialog() ==
                     DialogResult.OK) //check for OK...they might press cancel, so don't do anything if they did.
                 {
-                    var path = dialog.SelectedPath + "\\games.csv";
+                    var path = dialog.SelectedPath + sio.Path.DirectorySeparatorChar + "games.csv";
                     GameDataTable(dgvGameListPath).ToCSV(path);
                 }
             }
@@ -4430,7 +4450,7 @@ namespace GCBM
                         else
                             AudioDSP = " --audio_emulation=HLE";
 
-                        START_INFO.Arguments = " --exec=" + "\"" + _sourceGame + "\"" + " /b " + VideoDX + AudioDSP;
+                        START_INFO.Arguments = " --exec=" + sio.Path.DirectorySeparatorChar + _sourceGame + sio.Path.DirectorySeparatorChar + " /b " + VideoDX + AudioDSP;
                         //START_INFO.WindowStyle = ProcessWindowStyle.Hidden;
                         Process.Start(START_INFO);
                     }
@@ -4688,7 +4708,7 @@ namespace GCBM
 
                         // Nome do jogo
                         var _SwapCharacter = tbIDName.Text.Replace(":", " - ").Replace(";", " - ").Replace(",", " - ")
-                            .Replace(" -  ", " - ");
+                            .Replace(" -  ", " - ").Replace("/", "&");
 
                         var _source =
                             new sio.FileInfo(sio.Path.Combine(fbd1.SelectedPath, InstallQueue[intQueuePos].Path));
@@ -4696,39 +4716,39 @@ namespace GCBM
                         // Disc 1 (0 -> 0) - Title [ID Game]
                         if (tbIDDiscID.Text == "0x00" && CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 0)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                           _SwapCharacter + " [" + _IDMakerCode + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                                 _SwapCharacter + " [" + InstallQueue[intQueuePos].ID +
-                                                                "]" + @"\" + "game.iso");
+                                                                "]" + sio.Path.DirectorySeparatorChar + "game.iso");
                             CopyTask(_source, _destination);
                         } // Disc 2 (1 -> 0) - Title [ID Game]
                         else if (tbIDDiscID.Text == "0x01" &&
                                  CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 0)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                           _SwapCharacter + " [" + InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                                 _SwapCharacter + " [" + InstallQueue[intQueuePos].ID +
-                                                                "]" + @"\" + "disc2.iso");
+                                                                "]" + sio.Path.DirectorySeparatorChar + "disc2.iso");
                             CopyTask(_source, _destination);
                         } // Disc 1 (0 -> 1) - [ID Game]
                         else if (tbIDDiscID.Text == "0x00" &&
                                  CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 1)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
                                                           InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
-                                                                InstallQueue[intQueuePos].ID + "]" + @"\" + "game.iso");
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
+                                                                InstallQueue[intQueuePos].ID + "]" + sio.Path.DirectorySeparatorChar + "game.iso");
                             CopyTask(_source, _destination);
                         } // Disc 2 (1 -> 1) - [ID Game]
                         else if (tbIDDiscID.Text == "0x01" &&
                                  CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 1)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
                                                           InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
-                                                                InstallQueue[intQueuePos].ID + "]" + @"\" +
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
+                                                                InstallQueue[intQueuePos].ID + "]" + sio.Path.DirectorySeparatorChar +
                                                                 "disc2.iso");
                             CopyTask(_source, _destination);
                         }
@@ -4739,6 +4759,7 @@ namespace GCBM
                     catch (Exception ex)
                     {
                         tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                        tbLog.AppendText(ex.StackTrace);
                         GlobalNotifications(ex.Message, ToolTipIcon.Error);
                     }
             }
@@ -4836,7 +4857,7 @@ namespace GCBM
             START_INFO.CreateNoWindow = true;
             START_INFO.UseShellExecute = true;
             // GCIT
-            START_INFO.FileName = GET_CURRENT_PATH + @"\bin\gcit.exe ";
+            START_INFO.FileName = GET_CURRENT_PATH + sio.Path.DirectorySeparatorChar + "bin" + sio.Path.DirectorySeparatorChar + "gcit.exe ";
 
 
             var boolCaseSwitch = CONFIG_INI_FILE.IniReadBool("TRANSFERSYSTEM", "ScrubFlushSD");
@@ -4918,16 +4939,16 @@ namespace GCBM
                         if (CONFIG_INI_FILE.IniReadBool("TITLES", "GameInternalName"))
                         {
                             // Renomear - Rename game.iso -> disc2.iso
-                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" + tbIDName.Text + " [" +
-                                           tbIDGame.Text + "2]" + @"\game.iso";
-                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + tbIDName.Text + " [" +
+                                           tbIDGame.Text + "2]" + sio.Path.DirectorySeparatorChar + "game.iso";
+                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                             tbIDName.Text.Replace("disc2 ", "") + " [" + tbIDGame.Text + "2]" +
-                                            @"\disc2.iso";
+                                            sio.Path.DirectorySeparatorChar + "disc2.iso";
 
 
                             sio.File.Move(myOrigem, myDestiny);
 
-                            GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                            //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                             //We moved the file
 
                             //GC.Collect();
@@ -4936,11 +4957,11 @@ namespace GCBM
                         else
                         {
                             // Renomear game.iso -> disc2.iso
-                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" + _oldNameInternal + " [" +
-                                           tbIDGame.Text + "2]" + @"\game.iso";
-                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var myOrigem = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + _oldNameInternal + " [" +
+                                           tbIDGame.Text + "2]" + sio.Path.DirectorySeparatorChar + "game.iso";
+                            var myDestiny = tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                             _oldNameInternal.Replace("disc2 ", "") + " [" + tbIDGame.Text + "2]" +
-                                            @"\disc2.iso";
+                                            sio.Path.DirectorySeparatorChar + "disc2.iso";
 
                             //MessageBox.Show("MYORIGEM: " + Environment.NewLine
                             //    + myOrigem +
@@ -4954,7 +4975,7 @@ namespace GCBM
 
                             sio.File.Move(myOrigem, myDestiny);
 
-                            GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                            //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                             //MessageBox.Show(GCBM.Properties.Resources.InstallGameScrub_String6, GCBM.Properties.Resources.Information, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                             lblCopy.Visible = false;
@@ -5044,7 +5065,7 @@ namespace GCBM
 
                         // Nome do jogo
                         var _SwapCharacter = InstallQueue[intQueuePos].Title.Replace(":", " - ").Replace(";", " - ")
-                            .Replace(",", " - ").Replace(" -  ", " - ");
+                            .Replace(",", " - ").Replace(" -  ", " - ").Replace("/", "&");
 
                         //string strResult = "";
                         //bool firstCharacter = true;
@@ -5075,39 +5096,39 @@ namespace GCBM
                         // Disc 1 (0 -> 0) - Title [ID Game]
                         if (tbIDDiscID.Text == "0x00" && CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 0)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                           _SwapCharacter + " [" + InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                                 _SwapCharacter + " [" + InstallQueue[intQueuePos].ID +
-                                                                "]" + @"\" + "game.iso");
+                                                                "]" + sio.Path.DirectorySeparatorChar + "game.iso");
                             oldCopyTask(_source, _destination);
                         } // Disc 2 (1 -> 0) - Title [ID Game]
                         else if (tbIDDiscID.Text == "0x01" &&
                                  CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 0)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                           _SwapCharacter + " [" + InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\" +
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar +
                                                                 _SwapCharacter + " [" + InstallQueue[intQueuePos].ID +
-                                                                "]" + @"\" + "disc2.iso");
+                                                                "]" + sio.Path.DirectorySeparatorChar + "disc2.iso");
                             oldCopyTask(_source, _destination);
                         } // Disc 1 (0 -> 1) - [ID Game]
                         else if (tbIDDiscID.Text == "0x00" &&
                                  CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 1)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
                                                           InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
-                                                                InstallQueue[intQueuePos].ID + "]" + @"\" + "game.iso");
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
+                                                                InstallQueue[intQueuePos].ID + "]" + sio.Path.DirectorySeparatorChar + "game.iso");
                             oldCopyTask(_source, _destination);
                         } // Disc 2 (1 -> 1) - [ID Game]
                         else if (tbIDDiscID.Text == "0x01" &&
                                  CONFIG_INI_FILE.IniReadInt("SEVERAL", "AppointmentStyle") == 1)
                         {
-                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
+                            sio.Directory.CreateDirectory(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
                                                           InstallQueue[intQueuePos].ID + "]");
-                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + @"\[" +
-                                                                InstallQueue[intQueuePos].ID + "]" + @"\" +
+                            var _destination = new sio.FileInfo(tscbDiscDrive.SelectedItem + GAMES_DIR + sio.Path.DirectorySeparatorChar + "[" +
+                                                                InstallQueue[intQueuePos].ID + "]" + sio.Path.DirectorySeparatorChar +
                                                                 "disc2.iso");
                             oldCopyTask(_source, _destination);
                         }
@@ -5118,6 +5139,7 @@ namespace GCBM
                     catch (Exception ex)
                     {
                         tbLog.AppendText("[" + DateString() + "]" + Resources.Error + ex.Message + Environment.NewLine);
+                        tbLog.AppendText(ex.StackTrace);
                         GlobalNotifications(ex.Message, ToolTipIcon.Error);
                     }
             }
@@ -5220,7 +5242,7 @@ namespace GCBM
                     lblCopy.Text = Resources.CopyTask_String3;
                     lblInstallGame.Text = Resources.CopyTask_String4;
                     lblPercent.Text = Resources.CopyTask_String5;
-                    GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
+                    //GlobalNotifications(Resources.InstallGameScrub_String5, ToolTipIcon.Info);
 
                     pbCopy.Visible = false;
                     lblCopy.Visible = false;
@@ -5234,9 +5256,10 @@ namespace GCBM
                         {
                             InstallGameExactCopy(InstallQueue[intQueuePos].Path);
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            tbLog.Text += "\n" + DateTime.Now + " Error Installing: \n" + e.Message + "\n";
+                            tbLog.AppendText("[" + DateTime.Now + "] Error Installing: " + Environment.NewLine + ex.Message + Environment.NewLine);
+                            tbLog.AppendText(ex.StackTrace);
                         }
                     }
                     else
@@ -5271,7 +5294,7 @@ namespace GCBM
                     lblCopy.Text = Resources.CopyTask_String6;
                     lblInstallGame.Text = Resources.CopyTask_String4;
                     lblPercent.Text = Resources.CopyTask_String5;
-                    GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
+                    //GlobalNotifications(Resources.InstallGameScrub_String6, ToolTipIcon.Info);
                     pbCopy.Visible = false;
                     lblCopy.Visible = false;
                     lblPercent.Visible = false;
@@ -5284,9 +5307,9 @@ namespace GCBM
                         {
                             InstallGameExactCopy(InstallQueue[intQueuePos].Path);
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            tbLog.Text += "\n" + DateTime.Now + " Error Installing: \n" + e.Message + "\n";
+                            tbLog.AppendText("[" + DateTime.Now + "] Error Installing: " + Environment.NewLine + ex.Message + Environment.NewLine);
                         }
                     }
                     else

--- a/GCBM/frmRenameISO.cs
+++ b/GCBM/frmRenameISO.cs
@@ -14,7 +14,7 @@ namespace GCBM
             var _directoryName = Path.GetDirectoryName(NEW_NAME);
             var _fileName = Path.GetFileName(NEW_NAME);
             var ret = Regex.Replace(_fileName,
-                @"[^0-9a-zA-ZéúíóáÉÚÍÓÁèùìòàÈÙÌÒÀõãñÕÃÑêûîôâÊÛÎÔÂëÿüïöäËYÜÏÖÄçÇ[\]\-().]+?", string.Empty);
+                @"[^0-9a-zA-ZéúíóáÉÚÍÓÁèùìòàÈÙÌÒÀõãñÕÃÑêûîôâÊÛÎÔÂëÿüïöäËYÜÏÖÄçÇ[\]\-().]+?", string.Empty).Replace("/","&");
 
             if (chkRenameISO.Checked)
             {
@@ -24,9 +24,9 @@ namespace GCBM
 
                     if (!string.IsNullOrEmpty(newFilename))
                     {
-                        //File.Move(_oldName + @"\" + _newName, _oldName + @"\" + newFilename);
-                        File.Move(NEW_NAME, _directoryName + @"\" + newFilename);
-                        if (File.Exists(_directoryName + @"\" + newFilename))
+                        //File.Move(_oldName + Path.DirectorySeparatorChar + _newName, _oldName + Path.DirectorySeparatorChar + newFilename);
+                        File.Move(NEW_NAME, _directoryName + Path.DirectorySeparatorChar + newFilename);
+                        if (File.Exists(_directoryName + Path.DirectorySeparatorChar + newFilename))
                         {
                             ConfirmRename(newFilename);
 
@@ -44,8 +44,8 @@ namespace GCBM
                     var newFilename = tbRenameISO.Text;
                     if (!string.IsNullOrEmpty(newFilename))
                     {
-                        File.Move(NEW_NAME, _directoryName + @"\" + newFilename);
-                        if (File.Exists(_directoryName + @"\" + newFilename))
+                        File.Move(NEW_NAME, _directoryName + Path.DirectorySeparatorChar + newFilename);
+                        if (File.Exists(_directoryName + Path.DirectorySeparatorChar + newFilename))
                         {
                             ConfirmRename(newFilename);
 

--- a/GCBM/frmSplashScreen.cs
+++ b/GCBM/frmSplashScreen.cs
@@ -125,6 +125,7 @@ namespace GCBM
             catch (Exception ex)
             {
                 //not implemented!
+                MessageBox.Show(ex.Message);
             }
         }
 

--- a/GCBM/frmTransferCover.cs
+++ b/GCBM/frmTransferCover.cs
@@ -92,45 +92,45 @@ namespace GCBM
                 try
                 {
                     var _filesDisc =
-                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + @"\" +
-                                           REGION_GAME + @"\disc");
+                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + Path.DirectorySeparatorChar +
+                                           REGION_GAME + Path.DirectorySeparatorChar + "disc");
                     var _files2D =
-                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + @"\" +
-                                           REGION_GAME + @"\2d");
+                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + Path.DirectorySeparatorChar +
+                                           REGION_GAME + Path.DirectorySeparatorChar + "2d");
                     var _files3D =
-                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + @"\" +
-                                           REGION_GAME + @"\3d");
+                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + Path.DirectorySeparatorChar +
+                                           REGION_GAME + Path.DirectorySeparatorChar + "3d");
                     var _filesFull =
-                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + @"\" +
-                                           REGION_GAME + @"\full");
+                        Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") + Path.DirectorySeparatorChar +
+                                           REGION_GAME + Path.DirectorySeparatorChar + "full");
 
                     var _destFiles = "";
                     // Disc
                     foreach (var source in _filesDisc)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _targetDisc + @"\" + _destFiles, true);
+                        File.Copy(source, _targetDisc + Path.DirectorySeparatorChar + _destFiles, true);
                     }
 
                     // 2D
                     foreach (var source in _files2D)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _target2D + @"\" + _destFiles, true);
+                        File.Copy(source, _target2D + Path.DirectorySeparatorChar + _destFiles, true);
                     }
 
                     // 3D
                     foreach (var source in _files3D)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _target3D + @"\" + _destFiles, true);
+                        File.Copy(source, _target3D + Path.DirectorySeparatorChar + _destFiles, true);
                     }
 
                     // Full
                     foreach (var source in _filesFull)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _targetFull + @"\" + _destFiles, true);
+                        File.Copy(source, _targetFull + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -144,13 +144,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\3d");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "3d");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _target3DCovers + @"\" + _destFiles, true);
+                        File.Copy(source, _target3DCovers + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -162,13 +162,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\full");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "full");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _targetBoxCovers + @"\" + _destFiles, true);
+                        File.Copy(source, _targetBoxCovers + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -209,13 +209,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\disc");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "disc");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _targetDisc + @"\" + _destFiles, true);
+                        File.Copy(source, _targetDisc + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -227,13 +227,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\2d");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "2d");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _target2D + @"\" + _destFiles, true);
+                        File.Copy(source, _target2D + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -245,13 +245,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\3d");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "3d");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _target3D + @"\" + _destFiles, true);
+                        File.Copy(source, _target3D + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -263,13 +263,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\full");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "full");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _targetFull + @"\" + _destFiles, true);
+                        File.Copy(source, _targetFull + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -283,13 +283,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\3d");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "3d");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _target3DCovers + @"\" + _destFiles, true);
+                        File.Copy(source, _target3DCovers + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)
@@ -301,13 +301,13 @@ namespace GCBM
                 try
                 {
                     var _files = Directory.GetFiles(CONFIG_INI_FILE.IniReadString("COVERS", "CoverDirectoryCache", "") +
-                                                    @"\" + REGION_GAME + @"\full");
+                                                    Path.DirectorySeparatorChar + REGION_GAME + Path.DirectorySeparatorChar + "full");
                     var _destFiles = "";
 
                     foreach (var source in _files)
                     {
                         _destFiles = Path.GetFileName(source);
-                        File.Copy(source, _targetBoxCovers + @"\" + _destFiles, true);
+                        File.Copy(source, _targetBoxCovers + Path.DirectorySeparatorChar + _destFiles, true);
                     }
                 }
                 catch (Exception ex)

--- a/GCBM/image.cs
+++ b/GCBM/image.cs
@@ -62,13 +62,13 @@ namespace GCBM
             }
             else
             {
-                errorText = Resources.ReadImage_String1;
+                errorText = Resources.ReadImage_String1 + " " + IMAGE_PATH;
                 error = true;
             }
 
             if (fsr.Length < toc.dataStart)
             {
-                errorText = Resources.ReadImage_String1;
+                errorText = Resources.ReadImage_String1 + " " + IMAGE_PATH + ": expected length of " + toc.dataStart + " but got " + fsr.Length + ".";
                 error = true;
             }
 
@@ -137,12 +137,12 @@ namespace GCBM
                         }
                         else
                         {
-                            itemPath = itemPath.Insert(0, toc.fils[j].name + '\\');
+                            itemPath = itemPath.Insert(0, toc.fils[j].name + sio.Path.DirectorySeparatorChar);
                             j = toc.fils[j].dirIdx;
                         }
 
                     if (itemIsDir)
-                        itemPath += '\\';
+                        itemPath += sio.Path.DirectorySeparatorChar;
 
                     if (RETRIEVE_FILES_INFO)
                     {
@@ -248,13 +248,13 @@ namespace GCBM
             }
             else
             {
-                errorText = Resources.ReadImage_String1;
+                errorText = Resources.ReadImage_String1 + " " + IMAGE_PATH;
                 error = true;
             }
 
             if (fsr.Length < toc.dataStart)
             {
-                errorText = Resources.ReadImage_String1;
+                errorText = Resources.ReadImage_String1 + " " + IMAGE_PATH + ": expected length of " + toc.dataStart + " but got " + fsr.Length + ".";
                 error = true;
             }
 
@@ -323,12 +323,12 @@ namespace GCBM
                         }
                         else
                         {
-                            itemPath = itemPath.Insert(0, toc.fils[j].name + '\\');
+                            itemPath = itemPath.Insert(0, toc.fils[j].name + sio.Path.DirectorySeparatorChar);
                             j = toc.fils[j].dirIdx;
                         }
 
                     if (itemIsDir)
-                        itemPath += '\\';
+                        itemPath += sio.Path.DirectorySeparatorChar;
 
                     if (RETRIEVE_FILES_INFO)
                     {

--- a/GCBM/tools/frmConvertELFtoDOL.cs
+++ b/GCBM/tools/frmConvertELFtoDOL.cs
@@ -50,7 +50,7 @@ namespace GCBM.tools
             startInfo.CreateNoWindow = true;
             startInfo.UseShellExecute = true;
             // Elf2Dol
-            startInfo.FileName = GET_CURRENT_PATH + @"\bin\elf2dol.exe ";
+            startInfo.FileName = GET_CURRENT_PATH + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "elf2dol.exe ";
             // Argumentos
             startInfo.Arguments = " -O binary " + textBoxELF.Text + " " + textBoxDOL.Text;
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;

--- a/GCBM/tools/frmCreatePackage.cs
+++ b/GCBM/tools/frmCreatePackage.cs
@@ -91,19 +91,19 @@ namespace GCBM.tools
             {
                 if (rbNoCompression.Checked)
                 {
-                    ZipFile.CreateFromDirectory(Path.GetDirectoryName(DGV_DIRECTORY), FBD_DIRECTORY + @"\" + NEW_FILE,
+                    ZipFile.CreateFromDirectory(Path.GetDirectoryName(DGV_DIRECTORY), FBD_DIRECTORY + Path.DirectorySeparatorChar + NEW_FILE,
                         CompressionLevel.NoCompression, true);
                     SuccessCompressingFile();
                 }
                 else if (rbFastCompression.Checked)
                 {
-                    ZipFile.CreateFromDirectory(Path.GetDirectoryName(DGV_DIRECTORY), FBD_DIRECTORY + @"\" + NEW_FILE,
+                    ZipFile.CreateFromDirectory(Path.GetDirectoryName(DGV_DIRECTORY), FBD_DIRECTORY + Path.DirectorySeparatorChar + NEW_FILE,
                         CompressionLevel.Fastest, true);
                     SuccessCompressingFile();
                 }
                 else
                 {
-                    ZipFile.CreateFromDirectory(Path.GetDirectoryName(DGV_DIRECTORY), FBD_DIRECTORY + @"\" + NEW_FILE,
+                    ZipFile.CreateFromDirectory(Path.GetDirectoryName(DGV_DIRECTORY), FBD_DIRECTORY + Path.DirectorySeparatorChar + NEW_FILE,
                         CompressionLevel.Optimal, true);
                     SuccessCompressingFile();
                 }

--- a/GCBM/tools/frmInstallApp.Designer.cs
+++ b/GCBM/tools/frmInstallApp.Designer.cs
@@ -1,5 +1,6 @@
 ﻿
 using System.ComponentModel;
+using System.IO;
 using System.Windows.Forms;
 
 namespace GCBM.tools
@@ -119,8 +120,8 @@ namespace GCBM.tools
             this.cbDestiny.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbDestiny.FormattingEnabled = true;
             this.cbDestiny.Items.AddRange(new object[] {
-            "\\",
-            "\\apps"});
+            Path.DirectorySeparatorChar,
+            Path.DirectorySeparatorChar+ "apps"});
             this.cbDestiny.Location = new System.Drawing.Point(103, 29);
             this.cbDestiny.Name = "cbDestiny";
             this.cbDestiny.Size = new System.Drawing.Size(85, 21);

--- a/GCBM/tools/frmManageApp.cs
+++ b/GCBM/tools/frmManageApp.cs
@@ -29,7 +29,7 @@ namespace GCBM.tools
             //var findFolder = Directory.GetDirectories(folder, "*", SearchOption.AllDirectories);
             //var findFiles = Directory.GetFiles(folder, "*", SearchOption.AllDirectories);
 
-            var curFile = @"\boot.elf";
+            var curFile = Path.DirectorySeparatorChar + "boot.elf";
 
             foreach (var dir in Directory.GetDirectories(folder, "*", SearchOption.TopDirectoryOnly))
             foreach (var file in Directory.GetFiles(dir, "*", SearchOption.TopDirectoryOnly))

--- a/GCBM/tools/frmMetaXml.cs
+++ b/GCBM/tools/frmMetaXml.cs
@@ -82,9 +82,9 @@ namespace GCBM.tools
             var fileinfo = new FileInfo(ofdXml.FileName);
             var other = fileinfo.DirectoryName;
 
-            if (File.Exists(other + @"\icon.png"))
+            if (File.Exists(other + Path.DirectorySeparatorChar + "icon.png"))
             {
-                pbBanner.LoadAsync(other + @"\icon.png");
+                pbBanner.LoadAsync(other + Path.DirectorySeparatorChar + "icon.png");
                 btnAddBanner.Enabled = true;
                 btnDeleteBanner.Enabled = true;
                 btnClear.Enabled = true;
@@ -224,13 +224,13 @@ namespace GCBM.tools
         {
             var fileinfo = new FileInfo(ofdXml.FileName);
             var other = fileinfo.DirectoryName;
-            var xmlFile = @"\meta.xml";
+            var xmlFile = Path.DirectorySeparatorChar + "meta.xml";
 
             if (CheckEverything())
             {
                 File.WriteAllText(other + xmlFile, GenerateMetaXML());
                 // Save PictureBox
-                if (pbBanner.Image != null) pbBanner.Image.Save(other + @"\icon.png");
+                if (pbBanner.Image != null) pbBanner.Image.Save(other + Path.DirectorySeparatorChar + "icon.png");
 
                 MessageBox.Show(Resources.MetaXml_String2, Resources.Notice, MessageBoxButtons.OK,
                     MessageBoxIcon.Information);
@@ -264,7 +264,7 @@ namespace GCBM.tools
             {
                 var fileInfo = new FileInfo(ofdXml.FileName);
                 var other = fileInfo.DirectoryName;
-                var delFile = @"\icon.png";
+                var delFile = Path.DirectorySeparatorChar + "icon.png";
                 File.Delete(other + delFile);
                 btnDeleteBanner.Enabled = false;
                 pbBanner.Image = null;


### PR DESCRIPTION
Replace all instances of  `\` with the appropriate directory separator character
Replace all instances of `/` in game titles used as paths with `&` to prevent path issues
Print exception messages and/or stack traces to the log
Send fewer global notifications to prevent spam