### PR TITLE
Temp patch to allow nkit.iso files with "wrong sizes" to be used

### DIFF
--- a/GCBM/image.cs
+++ b/GCBM/image.cs
@@ -66,7 +66,7 @@ namespace GCBM
                 error = true;
             }
 
-            if (fsr.Length < toc.dataStart)
+            if (fsr.Length < toc.dataStart && !IMAGE_PATH.ToLower().EndsWith(".nkit.iso"))
             {
                 errorText = Resources.ReadImage_String1;
                 error = true;
@@ -252,7 +252,7 @@ namespace GCBM
                 error = true;
             }
 
-            if (fsr.Length < toc.dataStart)
+            if (fsr.Length < toc.dataStart && !IMAGE_PATH.ToLower().EndsWith(".nkit.iso"))
             {
                 errorText = Resources.ReadImage_String1;
                 error = true;


### PR DESCRIPTION
This only works for nkit.iso files before they're installed and the file extensions are changed to .iso. No file length integrity checking is done anymore on nkit.iso files, and no additional integrity checks have been implemented.

This should only be used temporarily until real nkit.iso support is implemented. Helps with #53, but does not close it.